### PR TITLE
Update CI to use opcode and use faketime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Install opcode
+      run: bash <(curl -Ls get.dannyb.co/opcode/setup)
+
     - name: Initialize git user
       run: |
         git config --global user.email "tester@approvals.com"
@@ -21,7 +24,7 @@ jobs:
       run: shellcheck git-changelog
 
     - name: Initialize test repo
-      run: test/init-repo
+      run: op sample-init
 
     - name: Run approval tests
-      run: test/approve
+      run: op test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: Install test dependencies
+      run: sudo apt install faketime
+
     - name: Install opcode
       run: bash <(curl -Ls get.dannyb.co/opcode/setup)
 

--- a/doc/git-changelog.1
+++ b/doc/git-changelog.1
@@ -7,7 +7,12 @@
 \f[B]git\-changelog\f[] \- Change Log Generator
 .SH SYNOPSIS
 .PP
-\f[B]git\-changelog\f[] [options | \-\-help]
+\f[B]git changelog\f[] [\-\-tail N] [\-\-reverse] [\-\-out PATH]
+[\-\-color MODE]
+.PD 0
+.P
+.PD
+\f[B]git changelog\f[] [\-\-save]
 .SH DESCRIPTION
 .PP
 \f[B]git\-changelog\f[] is a bash script that generates a human readable
@@ -42,9 +47,9 @@ Save output to a file.
 .RS
 .RE
 .TP
-.B \-c, \-\-color OPTION
+.B \-c, \-\-color MODE
 Enable or disable color.
-Supported options: \f[I]yes\f[], \f[I]on\f[], \f[I]always\f[],
+Supported modes: \f[I]yes\f[], \f[I]on\f[], \f[I]always\f[],
 \f[I]no\f[], \f[I]off\f[], \f[I]never\f[], \f[I]auto\f[].
 .RS
 .RE

--- a/doc/manpage.md
+++ b/doc/manpage.md
@@ -14,7 +14,8 @@ NAME
 SYNOPSIS
 ==================================================
 
-**git-changelog** [options | --help]
+**git changelog** [--tail N] [--reverse] [--out PATH] [--color MODE]  
+**git changelog** [--save]
 
 
 DESCRIPTION
@@ -45,9 +46,9 @@ OPTIONS
 -o, --out PATH
 :    Save output to a file.
 
--c, --color OPTION
+-c, --color MODE
 :    Enable or disable color.
-     Supported options: *yes*, *on*, *always*, *no*, *off*, *never*, *auto*.
+     Supported modes: *yes*, *on*, *always*, *no*, *off*, *never*, *auto*.
 
 -s, --save
 :    Shortcut for **--reverse --out CHANGELOG.md**.

--- a/git-changelog
+++ b/git-changelog
@@ -70,8 +70,8 @@ git_changelog_usage() {
     echo
     
     # :flag.usage
-    echo "  --color, -c OPTION"
-    printf "    Enable or disable color. Supported options:\n    - yes, on, always\n    - no, off, never\n    - auto\n"
+    echo "  --color, -c MODE"
+    printf "    Enable or disable color. Supported modes:\n    - yes, on, always\n    - no, off, never\n    - auto\n"
     printf "    Default: auto\n"
     echo
     
@@ -321,7 +321,7 @@ parse_requirements() {
         shift
         shift
       else
-        printf "%s\n" "--color requires an argument: --color, -c OPTION"
+        printf "%s\n" "--color requires an argument: --color, -c MODE"
         exit 1
       fi
       ;;

--- a/op.conf
+++ b/op.conf
@@ -6,19 +6,16 @@ install: sudo install git-changelog /usr/local/bin/
 watch: filewatcher --immediate "src/**/*" "bashly g && op install"
 #? Watch src folder and rebuild
 
-test: test/approve
+test: faketime '2020-09-28 08:00' test/approve
 #? Run approval tests
 
 shellcheck: shellcheck git-changelog && echo "PASS"
 #? Run shellcheck
 
-test-init: faketime '2020-09-28 08:00' test/init-repo
-#? Initialize sample repo for tests
-
-sample: cd ./test/sample-repo ; ../../git-changelog
+sample: cd ./test/sample-repo && ../../git-changelog
 #? Run 'git changelog' inside the test repo
 
-sample-init: faketime '2020-09-28 08:00' test/approve
+sample-init: faketime '2020-09-28 08:00' test/init-repo
 #? Initialize the sample repository
 
 man-dev: pandoc -s --to man doc/manpage.md | man -l -

--- a/op.conf
+++ b/op.conf
@@ -12,13 +12,13 @@ test: test/approve
 shellcheck: shellcheck git-changelog && echo "PASS"
 #? Run shellcheck
 
-test-init: test/init-repo
+test-init: faketime '2020-09-28 08:00' test/init-repo
 #? Initialize sample repo for tests
 
 sample: cd ./test/sample-repo ; ../../git-changelog
 #? Run 'git changelog' inside the test repo
 
-sample-init: test/init-repo
+sample-init: faketime '2020-09-28 08:00' test/approve
 #? Initialize the sample repository
 
 man-dev: pandoc -s --to man doc/manpage.md | man -l -

--- a/setup
+++ b/setup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo "=== Saving executable at /usr/local/bin/git-changelog"
+echo "=== Saving executable to /usr/local/bin/git-changelog"
 CURL_COMMAND="curl -s https://raw.githubusercontent.com/DannyBen/git-changelog/master/git-changelog > /usr/local/bin/git-changelog"
 if [[ $EUID -ne 0 ]]; then
   sudo bash -c "$CURL_COMMAND"

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -19,9 +19,9 @@ flags:
 
 - long: --color
   short: -c
-  arg: option
+  arg: mode
   default: auto
-  help: "Enable or disable color. Supported options:\n- yes, on, always\n- no, off, never\n- auto"
+  help: "Enable or disable color. Supported modes:\n- yes, on, always\n- no, off, never\n- auto"
 
 - long: --save
   short: -s

--- a/test/approvals/git_changelog_help
+++ b/test/approvals/git_changelog_help
@@ -21,8 +21,8 @@ Options:
   --out, -o PATH
     Save output to a file
 
-  --color, -c OPTION
-    Enable or disable color. Supported options:
+  --color, -c MODE
+    Enable or disable color. Supported modes:
     - yes, on, always
     - no, off, never
     - auto


### PR DESCRIPTION
This PR makes the tests a little more robust, by:

- Using faketime to fool the system into thinking its a specific date before initializing the sample repo, and before running the tests (since the approval tests have dates in them).
- Using opcode in GitHub actions, so the test commands are the same when running locally and in CI.