### PR TITLE
Add support for creating links for tag comparison (`CHANGELOG_COMPARE_URL`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,34 @@
 Change Log
 ========================================
 
+Untagged - Latest
+----------------------------------------
+
+- Add support for creating links for commits (`CHANGELOG_COMMIT_URL`) [`4010aa2`](https://github.com/DannyBen/git-changelog/commit/4010aa2)
+- Compare [`v0.2.0..HEAD`](https://github.com/dannyben/git-changelog/compare/v0.2.0..HEAD)
+
+
 v0.2.0 - 2024-02-26
 ----------------------------------------
 
 - Generate with bashly 1.1.0 [`55223e7`](https://github.com/DannyBen/git-changelog/commit/55223e7)
 - Update setup script [`13f8168`](https://github.com/DannyBen/git-changelog/commit/13f8168)
 - Add ability to merge with existing content using a break marker [`4f95a91`](https://github.com/DannyBen/git-changelog/commit/4f95a91)
+- Compare [`v0.1.14..v0.2.0`](https://github.com/dannyben/git-changelog/compare/v0.1.14..v0.2.0)
 
 
 v0.1.14 - 2023-08-26
 ----------------------------------------
 
 - Update usage texts and manpage [`af44256`](https://github.com/DannyBen/git-changelog/commit/af44256)
+- Compare [`v0.1.13..v0.1.14`](https://github.com/dannyben/git-changelog/compare/v0.1.13..v0.1.14)
 
 
 v0.1.13 - 2023-04-26
 ----------------------------------------
 
 - Regenerate with bashly 1.0.3 [`6ef0631`](https://github.com/DannyBen/git-changelog/commit/6ef0631)
+- Compare [`v0.1.12..v0.1.13`](https://github.com/dannyben/git-changelog/compare/v0.1.12..v0.1.13)
 
 
 v0.1.12 - 2022-05-23
@@ -26,42 +36,49 @@ v0.1.12 - 2022-05-23
 
 - Regenerate with bashly 0.8.0 [`e78a5a1`](https://github.com/DannyBen/git-changelog/commit/e78a5a1)
 - Fix manpage and -h in a non repo folder [`429d389`](https://github.com/DannyBen/git-changelog/commit/429d389)
+- Compare [`v0.1.11..v0.1.12`](https://github.com/dannyben/git-changelog/compare/v0.1.11..v0.1.12)
 
 
 v0.1.11 - 2022-05-12
 ----------------------------------------
 
 - Regenerate with bashly 0.8.0 [`b97d441`](https://github.com/DannyBen/git-changelog/commit/b97d441)
+- Compare [`v0.1.10..v0.1.11`](https://github.com/dannyben/git-changelog/compare/v0.1.10..v0.1.11)
 
 
 v0.1.10 - 2021-01-01
 ----------------------------------------
 
 - Add git changelog -2 shortcut [`ec77ba6`](https://github.com/DannyBen/git-changelog/commit/ec77ba6)
+- Compare [`v0.1.9..v0.1.10`](https://github.com/dannyben/git-changelog/compare/v0.1.9..v0.1.10)
 
 
 v0.1.9 - 2020-10-19
 ----------------------------------------
 
 - Add '-1' as a shortcut for '--tail 1' [`22f0ae7`](https://github.com/DannyBen/git-changelog/commit/22f0ae7)
+- Compare [`v0.1.8..v0.1.9`](https://github.com/dannyben/git-changelog/compare/v0.1.8..v0.1.9)
 
 
 v0.1.8 - 2020-10-18
 ----------------------------------------
 
 - Avoid printing 'Change Log' title when using --tail [`34514e8`](https://github.com/DannyBen/git-changelog/commit/34514e8)
+- Compare [`v0.1.7..v0.1.8`](https://github.com/dannyben/git-changelog/compare/v0.1.7..v0.1.8)
 
 
 v0.1.7 - 2020-10-06
 ----------------------------------------
 
 - Abort gracefully in a non-repo directory, or in a repo without tags [`41ffe34`](https://github.com/DannyBen/git-changelog/commit/41ffe34)
+- Compare [`v0.1.6..v0.1.7`](https://github.com/dannyben/git-changelog/compare/v0.1.6..v0.1.7)
 
 
 v0.1.6 - 2020-09-28
 ----------------------------------------
 
 - Fix --tail when there are no loose commits [`b4ccbfd`](https://github.com/DannyBen/git-changelog/commit/b4ccbfd)
+- Compare [`v0.1.5..v0.1.6`](https://github.com/dannyben/git-changelog/compare/v0.1.5..v0.1.6)
 
 
 v0.1.5 - 2020-09-28
@@ -69,12 +86,14 @@ v0.1.5 - 2020-09-28
 
 - Improve --tail and add --reverse [`ccfdfcf`](https://github.com/DannyBen/git-changelog/commit/ccfdfcf)
 - Add --save (shortcut for --reverse --out CHANGELOG.md) [`20d3812`](https://github.com/DannyBen/git-changelog/commit/20d3812)
+- Compare [`v0.1.4..v0.1.5`](https://github.com/dannyben/git-changelog/compare/v0.1.4..v0.1.5)
 
 
 v0.1.4 - 2020-09-26
 ----------------------------------------
 
 - Fix tag order [`60fd029`](https://github.com/DannyBen/git-changelog/commit/60fd029)
+- Compare [`v0.1.3..v0.1.4`](https://github.com/dannyben/git-changelog/compare/v0.1.3..v0.1.4)
 
 
 v0.1.3 - 2020-09-26
@@ -83,23 +102,27 @@ v0.1.3 - 2020-09-26
 - Fix manpage options [`ab784c2`](https://github.com/DannyBen/git-changelog/commit/ab784c2)
 - Show latest (untagged) changes [`4c83874`](https://github.com/DannyBen/git-changelog/commit/4c83874)
 - Fix reversed log order [`026d6bd`](https://github.com/DannyBen/git-changelog/commit/026d6bd)
+- Compare [`v0.1.2..v0.1.3`](https://github.com/dannyben/git-changelog/compare/v0.1.2..v0.1.3)
 
 
 v0.1.2 - 2020-09-25
 ----------------------------------------
 
 - Add manpage [`cc09724`](https://github.com/DannyBen/git-changelog/commit/cc09724)
+- Compare [`v0.1.1..v0.1.2`](https://github.com/dannyben/git-changelog/compare/v0.1.1..v0.1.2)
 
 
 v0.1.1 - 2020-09-25
 ----------------------------------------
 
 - Add --color flag [`6f31806`](https://github.com/DannyBen/git-changelog/commit/6f31806)
+- Compare [`v0.1.0..v0.1.1`](https://github.com/dannyben/git-changelog/compare/v0.1.0..v0.1.1)
 
 
 v0.1.0 - 2020-09-25
 ----------------------------------------
 
 - Initial version [`30fd7e0`](https://github.com/DannyBen/git-changelog/commit/30fd7e0)
+- Compare [`v0.1.0`](https://github.com/dannyben/git-changelog/compare/v0.1.0)
 
 

--- a/git-changelog
+++ b/git-changelog
@@ -126,6 +126,11 @@ git_changelog_usage() {
     printf "    Set a URL template for commit links. This is passed to 'git log' as part of\n    the '--format' option, so you can use '%%h' or '%%H' to denote the commit\n    hash.\n    \n    Example: https://github.com/DannyBen/git-changelog/commit/%%h\n"
     echo
 
+    # :environment_variable.usage
+    printf "  %s\n" "CHANGELOG_COMPARE_URL"
+    printf "    Set a URL template for comparing each tag with the previous tag. Use '%%s'\n    in your string to denote the ref range. When this is provided, an additional\n    bullet will be added to each block of changes with a comparison link.\n    \n    Example: https://github.com/dannyben/git-changelog/compare/%%s\n"
+    echo
+
     # :command.usage_examples
     printf "%s\n" "Examples:"
     printf "  git changelog --tail 3\n"
@@ -323,7 +328,14 @@ get_markdown() {
     fi
 
     printf -- "----------------------------------------\n\n"
-    printf "%s\n\n\n" "$commits"
+
+    if [[ -z $CHANGELOG_COMPARE_URL ]]; then
+      printf "%s\n\n\n" "$commits"
+    else
+      compare_url=$(printf "$CHANGELOG_COMPARE_URL" "$ref")
+      compare_link="Compare [\`$ref\`]($compare_url)"
+      printf "%s\n- %s\n\n\n" "$commits" "$compare_link"
+    fi
   done
 }
 
@@ -453,6 +465,7 @@ parse_requirements() {
   # :command.environment_variables_filter
 
   env_var_names+=("CHANGELOG_COMMIT_URL")
+  env_var_names+=("CHANGELOG_COMPARE_URL")
 
   # :command.dependencies_filter
   if command -v git >/dev/null 2>&1; then

--- a/git-changelog
+++ b/git-changelog
@@ -332,6 +332,8 @@ get_markdown() {
     if [[ -z $CHANGELOG_COMPARE_URL ]]; then
       printf "%s\n\n\n" "$commits"
     else
+      # shellcheck disable=SC2059
+      # Disabling SC2059 (quoted format string) because we use dynamic format strings
       compare_url=$(printf "$CHANGELOG_COMPARE_URL" "$ref")
       compare_link="Compare [\`$ref\`]($compare_url)"
       printf "%s\n- %s\n\n\n" "$commits" "$compare_link"

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -52,6 +52,15 @@ environment_variables:
 
     Example: https://github.com/DannyBen/git-changelog/commit/%%h
 
+- name: changelog_compare_url
+  help: >
+    Set a URL template for comparing each tag with the previous tag. Use '%%s'
+    in your string to denote the ref range. When this is provided, an additional
+    bullet will be added to each block of changes with a comparison link.
+
+
+    Example: https://github.com/dannyben/git-changelog/compare/%%s
+
 flags:
 - long: --tail
   short: -t

--- a/src/lib/get_markdown.sh
+++ b/src/lib/get_markdown.sh
@@ -38,6 +38,8 @@ get_markdown() {
     if [[ -z $CHANGELOG_COMPARE_URL ]]; then
       printf "%s\n\n\n" "$commits"
     else
+      # shellcheck disable=SC2059
+      # Disabling SC2059 (quoted format string) because we use dynamic format strings
       compare_url=$(printf "$CHANGELOG_COMPARE_URL" "$ref")
       compare_link="Compare [\`$ref\`]($compare_url)"
       printf "%s\n- %s\n\n\n" "$commits" "$compare_link"

--- a/src/lib/get_markdown.sh
+++ b/src/lib/get_markdown.sh
@@ -34,6 +34,13 @@ get_markdown() {
     fi
 
     printf -- "----------------------------------------\n\n"
-    printf "%s\n\n\n" "$commits"
+
+    if [[ -z $CHANGELOG_COMPARE_URL ]]; then
+      printf "%s\n\n\n" "$commits"
+    else
+      compare_url=$(printf "$CHANGELOG_COMPARE_URL" "$ref")
+      compare_link="Compare [\`$ref\`]($compare_url)"
+      printf "%s\n- %s\n\n\n" "$commits" "$compare_link"
+    fi
   done
 }

--- a/test/approvals/compare_url
+++ b/test/approvals/compare_url
@@ -1,0 +1,40 @@
+Change Log
+========================================
+
+[32mv0.1.0[0m - [36m2020-09-28[0m
+----------------------------------------
+
+- Initial version
+- Compare [`v0.1.0`](http://github.com/repo/compare/v0.1.0)
+
+
+[32mv0.2.0[0m - [36m2020-09-28[0m
+----------------------------------------
+
+- Second change log item
+- The last commit in this tag
+- Compare [`v0.1.0..v0.2.0`](http://github.com/repo/compare/v0.1.0..v0.2.0)
+
+
+[32mv0.3.0[0m - [36m2020-09-28[0m
+----------------------------------------
+
+- This is the third version
+- This is a big version with multiple commits
+- Compare [`v0.2.0..v0.3.0`](http://github.com/repo/compare/v0.2.0..v0.3.0)
+
+
+[32m1.0.0[0m - [36m2020-09-28[0m
+----------------------------------------
+
+- Version without the v prefix
+- Compare [`v0.3.0..1.0.0`](http://github.com/repo/compare/v0.3.0..1.0.0)
+
+
+[32mUntagged[0m - [36mLatest[0m
+----------------------------------------
+
+- Unreleased change
+- Another unreleased change
+- Last unreleased change
+- Compare [`1.0.0..HEAD`](http://github.com/repo/compare/1.0.0..HEAD)

--- a/test/approvals/git_changelog_help
+++ b/test/approvals/git_changelog_help
@@ -58,6 +58,13 @@ Environment Variables:
     
     Example: https://github.com/DannyBen/git-changelog/commit/%h
 
+  CHANGELOG_COMPARE_URL
+    Set a URL template for comparing each tag with the previous tag. Use '%s'
+    in your string to denote the ref range. When this is provided, an additional
+    bullet will be added to each block of changes with a comparison link.
+    
+    Example: https://github.com/dannyben/git-changelog/compare/%s
+
 Examples:
   git changelog --tail 3
   git changelog --out CHANGELOG.md

--- a/test/approve
+++ b/test/approve
@@ -4,6 +4,7 @@ PATH="$PWD:$PATH"
 pushd test/sample-repo > /dev/null
 source "../approvals.bash"
 unset CHANGELOG_COMMIT_URL
+unset CHANGELOG_COMPARE_URL
 
 describe "git-changelog"
   context "in a folder that is a git repo"
@@ -27,6 +28,11 @@ describe "git-changelog"
     allow_diff "[a-z0-9]{7}"
     approve "git-changelog" commit_url
     unset CHANGELOG_COMMIT_URL
+
+  context "when CHANGELOG_COMPARE_URL is set"
+    export CHANGELOG_COMPARE_URL="http://github.com/repo/compare/%s"
+    approve "git-changelog" compare_url
+    unset CHANGELOG_COMPARE_URL
 
 describe "--help"
   approve "git-changelog --help"


### PR DESCRIPTION
Setting the environment variable `CHANGELOG_COMPARE_URL` to a URL, will add a last bullet to each tag;s changes, with a comparison link from the previous tag to this tag. `%s` will be replaced with the ref range (`v1.0.0..v1.1.0`).

GitHub comparison link template:

```bash
export CHANGELOG_COMPARE_URL=https://github.com/dannyben/git-changelog/compare/%s
```